### PR TITLE
Make `teamDownloadableAt` field nullable in validation

### DIFF
--- a/app/Http/Requests/UploadRequest.php
+++ b/app/Http/Requests/UploadRequest.php
@@ -36,7 +36,7 @@ class UploadRequest extends FormRequest
                     'teamDeletePassWord' => 'required|max:100',
                     'teamFile' => 'required|che_file|max:24',
                     'teamSearchTags.*' => 'max:100',
-                    'teamDownloadableAt' => 'date_format:Y-m-d\TH:i'
+                    'teamDownloadableAt' => 'nullable|date_format:Y-m-d\TH:i'
                 ];
             } else {
                 //'url'のなかに'simpleupload'が含まれてない場合（通常アップロード）
@@ -45,8 +45,7 @@ class UploadRequest extends FormRequest
                     'teamComment' => 'required|max:200',
                     'teamFile' => 'required|che_file|max:24',
                     'teamSearchTags.*' => 'max:100',
-                    'teamDownloadableAt' => 'date_format:Y-m-d\TH:i'
-
+                    'teamDownloadableAt' => 'nullable|date_format:Y-m-d\TH:i'
                 ];
             }
         } else {


### PR DESCRIPTION
Updated the `teamDownloadableAt` field validation rule to allow nullable values while maintaining the required date format. This enhances flexibility for cases where the field is optional. All other validation behavior remains unchanged.