### PR TITLE
Add local Docker Compose configuration

### DIFF
--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -1,0 +1,53 @@
+version: "3"
+services:
+  https-portal:
+    image: steveltn/https-portal:1
+    ports:
+      - 80:80
+      - 443:443
+    restart: always
+    environment:
+      DOMAINS: "${APP_DOMAIN} -> http://web:8000"
+      STAGE: ${APP_ENV}
+    volumes:
+      - https-portal-data:/var/lib/https-portal
+  web:
+    image: nginx:1.24.0-alpine
+    restart: always
+    expose:
+      - 8000
+    depends_on:
+      - https-portal
+    volumes:
+      - ./:/var/www/html
+      - node_modules_volume:/var/www/html/node_modules
+      - ./_docker-configs/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+  php-fpm:
+    build:
+      context: ./_docker-configs/php-fpm
+      args:
+        - NEW_RELIC_AGENT_VERSION=11.2.0.15
+        - NEW_RELIC_LICENSE_KEY=${NRIA_LICENSE_KEY}
+        - NEW_RELIC_APPNAME="project-europa - ${APP_ENV}"
+    depends_on:
+      - pg
+    working_dir: /var/www/html
+    volumes:
+      - ./:/var/www/html
+      - node_modules_volume:/var/www/html/node_modules
+  pg:
+    image: postgres:17-alpine
+    restart: always
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      - PGUSER=${PG_USER}
+      - POSTGRES_DB=${DB_DATABASE}
+      - POSTGRES_USER=${DB_USERNAME}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - db-store:/var/lib/postgresql/data
+volumes:
+  db-store:
+  https-portal-data:
+  node_modules_volume:


### PR DESCRIPTION
## 概要
ローカル開発環境用のDocker Compose設定ファイル `compose.local.yaml` を追加しました。

## 変更内容
- ローカル開発環境用の `compose.local.yaml` を作成
- 監視サービス（mackerel、new-relic）を削除してシンプルなローカル環境を構築
- cron サービスをローカル開発では不要なため削除
- コアサービスのみ保持: https-portal, web, php-fpm, pg
- コメントアウトされたボリュームと依存関係を削除してクリーンな設定に

## 使用方法
```bash
docker-compose -f compose.local.yaml up -d
```

## テスト
- [x] ファイルが正常に作成されることを確認
- [ ] ローカル環境での動作確認（必要に応じて）