### PR TITLE
fix: set dynamic initial date for calendar component

### DIFF
--- a/frontend/src/app/info/page.tsx
+++ b/frontend/src/app/info/page.tsx
@@ -83,7 +83,7 @@ const InformationPage: React.FC = () => {
                 width: '100%'
               }}>
                 <Calendar
-                  initialDate={new Date(2025, 4, 6)}
+                  initialDate={new Date()}
                   events={events.map(ev => ({
                     date: ev.event_closing_day,
                     title: ev.event_name,


### PR DESCRIPTION
Updated the `Calendar` component to use the current date as the initial date instead of a hardcoded value.