### PR TITLE
fix: チーム検索にオーナー名を追加

### DIFF
--- a/hono-worker/src/routes/files.ts
+++ b/hono-worker/src/routes/files.ts
@@ -78,10 +78,9 @@ files.get('/', optionalAuthMiddleware, async (c) => {
     }
 
     if (keyword) {
-      // SQLワイルドカード文字をエスケープ（%, _, \）
-      const escapedKeyword = keyword.replace(/[\\%_]/g, '\\$&');
-      // ILIKEパターンをSQL側で構築（ワイルドカードも含む）
-      whereConditions.push(sql`(file_name ILIKE '%' || ${escapedKeyword} || '%' OR file_comment ILIKE '%' || ${escapedKeyword} || '%' OR upload_owner_name ILIKE '%' || ${escapedKeyword} || '%')`);
+      // ILIKEパターンをSQL側で構築
+      // パラメータ化により${keyword}内の%や_は自動的にリテラル文字として扱われる
+      whereConditions.push(sql`(file_name ILIKE '%' || ${keyword} || '%' OR file_comment ILIKE '%' || ${keyword} || '%' OR upload_owner_name ILIKE '%' || ${keyword} || '%')`);
       whereConditions.push(sql`(downloadable_at IS NULL OR downloadable_at <= NOW())`);
     }
 


### PR DESCRIPTION
ファイル検索のキーワード検索において、upload_owner_name（オーナー名）を
検索対象に含めるように修正。これにより、例えば「Xtend」で検索すると、
そのオーナー名を持つすべてのチームが検索結果に表示されるようになる。

Fixes #287