### PR TITLE
docs: update Next.js version in README (15.4.8 → 15.4.10)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Next.js 15.xベースのフロントエンドアプリケーション
 *   **認証:** bcryptjs
 
 ### フロントエンド (frontend)
-*   **Next.js:** 15.4.8
+*   **Next.js:** 15.4.10
 *   **React:** 19.2.0
 *   **スタイリング:** TailwindCSS 4.1.7
 *   **UIコンポーネント:** shadcn/ui, Radix UI
@@ -222,7 +222,7 @@ sequenceDiagram
 ```mermaid
 graph LR
     subgraph "Frontend技術"
-        NextJS[Next.js 15.4.8]
+        NextJS[Next.js 15.4.10]
         React[React 19.2.0]
         TailwindCSS[TailwindCSS 4.1.7]
         TanStack[TanStack Query v5.83.0]


### PR DESCRIPTION
Address review feedback point 4 from PR #301 review. The actual installed version is 15.4.10 as per package-lock.json.