### PR TITLE
fix event validation handling and event type mapping

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -55,11 +55,15 @@ jobs:
             ## プロジェクト規約
             - frontend: React 19, Next.js 16, TailwindCSS 4, shadcn/ui
             - backend: Hono v4, Cloudflare Workers, Neon PostgreSQL
-            - 詳細は CLAUDE.md を参照
+            - CLAUDE.md は規約確認のためだけに参照してください。CLAUDE.md / README / skill docs の本文をPRコメントに貼り付けないでください。
 
-            `gh pr diff` でdiffを取得し、`gh pr comment` でレビューを投稿してください。
+            ## 投稿ルール
+            - `gh pr diff` でdiffを取得し、`gh pr comment` でレビューを1件だけ投稿してください。
+            - コメントは最大4000文字、要修正点を優先し、該当ファイルパスを明記してください。
+            - 問題がない場合は「重大な指摘はありません」と短く投稿してください。
+            - `gh pr comment` の投稿後、このActionの最終応答は `Review posted.` の1行だけにしてください。
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          use_sticky_comment: true
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
 
     steps:
@@ -55,15 +55,11 @@ jobs:
             ## プロジェクト規約
             - frontend: React 19, Next.js 16, TailwindCSS 4, shadcn/ui
             - backend: Hono v4, Cloudflare Workers, Neon PostgreSQL
-            - CLAUDE.md は規約確認のためだけに参照してください。CLAUDE.md / README / skill docs の本文をPRコメントに貼り付けないでください。
+            - 詳細は CLAUDE.md を参照
 
-            ## 投稿ルール
-            - `gh pr diff` でdiffを取得し、`gh pr comment` でレビューを1件だけ投稿してください。
-            - コメントは最大4000文字、要修正点を優先し、該当ファイルパスを明記してください。
-            - 問題がない場合は「重大な指摘はありません」と短く投稿してください。
-            - `gh pr comment` の投稿後、このActionの最終応答は `Review posted.` の1行だけにしてください。
+            `gh pr diff` でdiffを取得し、`gh pr comment` でレビューを投稿してください。
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          use_sticky_comment: true
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+

--- a/frontend/e2e/event.spec.ts
+++ b/frontend/e2e/event.spec.ts
@@ -79,12 +79,12 @@ test.describe('イベント登録', () => {
       }
 
       await route.fulfill({
-        status: 400,
+        status: 422,
         contentType: 'application/json',
         body: JSON.stringify({
           error: {
             message: 'Validation failed',
-            code: 'HTTP_400',
+            code: 'HTTP_422',
             details: {
               endDisplayDate: ['End display date must be after deadline'],
             },

--- a/frontend/e2e/event.spec.ts
+++ b/frontend/e2e/event.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+import { loginUser, testUsers } from './helpers/auth-helpers';
+import { EventPage } from './pages';
+
+const validEvent = {
+  name: 'E2Eイベント登録テスト',
+  details: 'E2Eからイベント登録できることを確認します。',
+  url: 'https://example.com/e2e-event',
+  deadline: '2026-05-01',
+  endDisplayDate: '2026-05-10',
+  type: 'tournament' as const,
+};
+
+test.describe('イベント登録', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginUser(page, testUsers.valid);
+  });
+
+  test('認証済みユーザーがイベントを登録できる', async ({ page }) => {
+    let requestBody: Record<string, unknown> | null = null;
+
+    await page.route('**/api/v2/events', async route => {
+      const request = route.request();
+      if (request.method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      const body = request.postDataJSON() as Record<string, unknown>;
+      requestBody = body;
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: 'Event created successfully',
+          data: {
+            event: {
+              id: 1001,
+              register_user_id: '1',
+              event_name: validEvent.name,
+              event_details: validEvent.details,
+              event_reference_url: validEvent.url,
+              event_type: '1',
+              event_closing_day: body.deadline,
+              event_displaying_day: body.endDisplayDate,
+              created_at: '2026-04-12T00:00:00.000Z',
+              updated_at: '2026-04-12T00:00:00.000Z',
+            },
+          },
+        }),
+      });
+    });
+
+    const eventPage = new EventPage(page);
+    await eventPage.goto();
+    await eventPage.expectVisible();
+
+    await eventPage.registerEvent(validEvent);
+    await eventPage.expectRegistrationSuccess();
+
+    expect(requestBody).toMatchObject({
+      name: validEvent.name,
+      details: validEvent.details,
+      url: validEvent.url,
+      type: '1',
+      deadline: new Date(`${validEvent.deadline}T23:59:59`).toISOString(),
+      endDisplayDate: new Date(
+        `${validEvent.endDisplayDate}T23:59:59`
+      ).toISOString(),
+    });
+  });
+
+  test('APIのバリデーションエラーを成功扱いにしない', async ({ page }) => {
+    await page.route('**/api/v2/events', async route => {
+      const request = route.request();
+      if (request.method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: {
+            message: 'Validation failed',
+            code: 'HTTP_400',
+            details: {
+              endDisplayDate: ['End display date must be after deadline'],
+            },
+          },
+        }),
+      });
+    });
+
+    const eventPage = new EventPage(page);
+    await eventPage.goto();
+    await eventPage.expectVisible();
+
+    await eventPage.registerEvent(validEvent);
+    await eventPage.expectRegistrationError();
+    await expect(
+      page.getByText('イベント情報が登録されました')
+    ).not.toBeVisible();
+  });
+});

--- a/frontend/e2e/pages/EventPage.ts
+++ b/frontend/e2e/pages/EventPage.ts
@@ -1,0 +1,131 @@
+import { expect, type Locator } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+export interface EventRegistrationData {
+  name: string;
+  details: string;
+  url?: string;
+  deadline: string;
+  endDisplayDate: string;
+  type?: 'tournament' | 'announcement' | 'other';
+}
+
+/**
+ * Event registration Page Object
+ */
+export class EventPage extends BasePage {
+  get heading() {
+    return this.page.getByRole('heading', {
+      name: 'イベント登録',
+      exact: true,
+    });
+  }
+
+  get nameInput() {
+    return this.page.getByLabel(/イベント名/);
+  }
+
+  get detailsInput() {
+    return this.page.getByLabel(/イベント詳細情報/);
+  }
+
+  get urlInput() {
+    return this.page.getByLabel(/イベント詳細URL/);
+  }
+
+  get deadlineInput() {
+    return this.page.getByLabel(/イベント受付締切日/);
+  }
+
+  get endDisplayDateInput() {
+    return this.page.getByLabel(/イベント表示最終日/);
+  }
+
+  get typeSelect() {
+    return this.page.getByLabel(/イベント種別/);
+  }
+
+  get submitButton() {
+    return this.page.getByRole('button', { name: /イベントを登録する/ });
+  }
+
+  get confirmDialog() {
+    return this.page.getByRole('dialog', { name: 'イベント登録内容の確認' });
+  }
+
+  get confirmButton() {
+    return this.confirmDialog.getByRole('button', {
+      name: '登録する',
+      exact: true,
+    });
+  }
+
+  get cancelButton() {
+    return this.confirmDialog.getByRole('button', { name: 'キャンセル' });
+  }
+
+  async goto() {
+    await this.page.goto('/event');
+  }
+
+  async fillDate(input: Locator, value: string) {
+    await input.evaluate(element => element.removeAttribute('readonly'));
+    await input.fill(value);
+  }
+
+  async fillForm(data: EventRegistrationData) {
+    await this.nameInput.fill(data.name);
+    await this.detailsInput.fill(data.details);
+
+    if (data.url) {
+      await this.urlInput.fill(data.url);
+    }
+
+    await this.fillDate(this.deadlineInput, data.deadline);
+    await this.fillDate(this.endDisplayDateInput, data.endDisplayDate);
+
+    if (data.type) {
+      await this.typeSelect.selectOption(data.type);
+    }
+  }
+
+  async submit() {
+    await this.submitButton.click();
+  }
+
+  async confirmRegistration() {
+    await this.confirmButton.click();
+  }
+
+  async registerEvent(data: EventRegistrationData) {
+    await this.fillForm(data);
+    await this.submit();
+    await this.expectConfirmDialogVisible();
+    await this.confirmRegistration();
+  }
+
+  async expectVisible() {
+    await expect(this.page).toHaveURL('/event');
+    await expect(this.heading).toBeVisible({ timeout: 5000 });
+    await expect(this.nameInput).toBeVisible();
+    await expect(this.detailsInput).toBeVisible();
+    await expect(this.deadlineInput).toBeVisible();
+    await expect(this.endDisplayDateInput).toBeVisible();
+    await expect(this.typeSelect).toBeVisible();
+    await expect(this.submitButton).toBeVisible();
+  }
+
+  async expectConfirmDialogVisible() {
+    await expect(this.confirmDialog).toBeVisible({ timeout: 5000 });
+  }
+
+  async expectRegistrationSuccess() {
+    await this.expectSuccessToast(/イベント情報が登録されました/);
+  }
+
+  async expectRegistrationError(
+    message: string | RegExp = /Validation failed/
+  ) {
+    await this.expectErrorToast(message);
+  }
+}

--- a/frontend/e2e/pages/EventPage.ts
+++ b/frontend/e2e/pages/EventPage.ts
@@ -69,6 +69,8 @@ export class EventPage extends BasePage {
   }
 
   async fillDate(input: Locator, value: string) {
+    // DatePicker uses readonly to force calendar interaction; remove it here
+    // so this E2E can provide deterministic dates without depending on calendar UI details.
     await input.evaluate(element => element.removeAttribute('readonly'));
     await input.fill(value);
   }

--- a/frontend/e2e/pages/index.ts
+++ b/frontend/e2e/pages/index.ts
@@ -14,9 +14,10 @@
  */
 
 export { BasePage } from './BasePage';
-export { LoginPage } from './LoginPage';
-export { RegisterPage } from './RegisterPage';
+export { EventPage } from './EventPage';
 export { HomePage } from './HomePage';
+export { LoginPage } from './LoginPage';
 export { MyPage } from './MyPage';
-export { SearchPage, TeamSearchPage, MatchSearchPage } from './SearchPage';
-export { UploadPage, TeamUploadPage, MatchUploadPage } from './UploadPage';
+export { RegisterPage } from './RegisterPage';
+export { MatchSearchPage, SearchPage, TeamSearchPage } from './SearchPage';
+export { MatchUploadPage, TeamUploadPage, UploadPage } from './UploadPage';

--- a/frontend/src/__tests__/lib/api/events.test.ts
+++ b/frontend/src/__tests__/lib/api/events.test.ts
@@ -77,7 +77,7 @@ describe('events API', () => {
     });
 
     it('should throw API errors so React Query can call onError', async () => {
-      const apiError = new ApiErrorClass(400, {
+      const apiError = new ApiErrorClass(422, {
         message: 'Validation failed',
         errors: { endDisplayDate: ['End display date must be after deadline'] },
       });

--- a/frontend/src/__tests__/lib/api/events.test.ts
+++ b/frontend/src/__tests__/lib/api/events.test.ts
@@ -49,6 +49,33 @@ describe('events API', () => {
       expect(result).toBe(mockResponse);
     });
 
+    it.each([
+      ['tournament', '1'],
+      ['announcement', '2'],
+      ['other', '3'],
+    ])('should convert %s event type to API type %s', async (eventType, apiType) => {
+      vi.mocked(apiClient.post).mockResolvedValueOnce({
+        message: 'Event created successfully',
+        data: { event: { id: 1 } },
+      });
+
+      await registerEvent({
+        name: 'テストイベント',
+        details: 'テストイベントの詳細です',
+        url: '',
+        deadline: '2024-12-31',
+        endDisplayDate: '2025-01-31',
+        type: eventType,
+      });
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/v2/events',
+        expect.objectContaining({
+          type: apiType,
+        })
+      );
+    });
+
     it('should throw API errors so React Query can call onError', async () => {
       const apiError = new ApiErrorClass(400, {
         message: 'Validation failed',
@@ -91,7 +118,7 @@ describe('events API', () => {
           event_reference_url: 'https://example2.com',
           event_closing_day: '2024-12-31',
           event_displaying_day: '2024-12-31',
-          event_type: 'other',
+          event_type: '3',
           created_at: '2024-01-01T00:00:00Z',
           updated_at: '2024-01-01T00:00:00Z',
           is_active: true,

--- a/frontend/src/__tests__/lib/api/events.test.ts
+++ b/frontend/src/__tests__/lib/api/events.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiClient } from '@/lib/api/client';
-import { fetchEvents } from '@/lib/api/events';
-import type { Event, } from '@/types/event';
+import { fetchEvents, registerEvent } from '@/lib/api/events';
+import { ApiErrorClass } from '@/types/api';
+import type { Event } from '@/types/event';
 
 // APIクライアントをモック
 vi.mock('@/lib/api/client', () => ({
@@ -21,8 +22,50 @@ describe('events API', () => {
   });
 
   describe('registerEvent', () => {
-    it.skip('should register event successfully (Not implemented in v2)', async () => {
-      // Skipped
+    it('should register event successfully', async () => {
+      const mockResponse = {
+        message: 'Event created successfully',
+        data: { event: { id: 1 } },
+      };
+      vi.mocked(apiClient.post).mockResolvedValueOnce(mockResponse);
+
+      const result = await registerEvent({
+        name: 'テストイベント',
+        details: 'テストイベントの詳細です',
+        url: 'https://example.com',
+        deadline: '2024-12-31',
+        endDisplayDate: '2025-01-31',
+        type: 'tournament',
+      });
+
+      expect(apiClient.post).toHaveBeenCalledWith('/api/v2/events', {
+        name: 'テストイベント',
+        details: 'テストイベントの詳細です',
+        url: 'https://example.com',
+        type: '1',
+        deadline: new Date('2024-12-31T23:59:59').toISOString(),
+        endDisplayDate: new Date('2025-01-31T23:59:59').toISOString(),
+      });
+      expect(result).toBe(mockResponse);
+    });
+
+    it('should throw API errors so React Query can call onError', async () => {
+      const apiError = new ApiErrorClass(400, {
+        message: 'Validation failed',
+        errors: { endDisplayDate: ['End display date must be after deadline'] },
+      });
+      vi.mocked(apiClient.post).mockRejectedValueOnce(apiError);
+
+      await expect(
+        registerEvent({
+          name: 'テストイベント',
+          details: 'テストイベントの詳細です',
+          url: '',
+          deadline: '2025-01-31',
+          endDisplayDate: '2024-12-31',
+          type: 'other',
+        })
+      ).rejects.toBe(apiError);
     });
   });
 

--- a/frontend/src/lib/api/events.ts
+++ b/frontend/src/lib/api/events.ts
@@ -47,6 +47,9 @@ const normalizeEventType = (type?: string | null): EventType => {
   if (type === '2' || type === 'announcement') {
     return 'announcement';
   }
+  if (type === '3' || type === 'other') {
+    return 'other';
+  }
   return 'other';
 };
 
@@ -55,10 +58,10 @@ const normalizeEventType = (type?: string | null): EventType => {
  */
 export const registerEvent = async (formData: EventFormData) => {
   // イベントタイプの変換
-  let type = '2'; // デフォルト: その他
+  let type = '3'; // デフォルト: その他
   if (formData.type === 'tournament') {
     type = '1';
-  } else if (formData.type === 'announcement' || formData.type === 'other') {
+  } else if (formData.type === 'announcement') {
     type = '2';
   }
 

--- a/frontend/src/lib/api/events.ts
+++ b/frontend/src/lib/api/events.ts
@@ -24,63 +24,82 @@ export interface EventFormData {
   type: string;
 }
 
+interface ApiEvent {
+  id: number | string;
+  event_name?: string | null;
+  event_details?: string | null;
+  event_reference_url?: string | null;
+  event_closing_day?: string | null;
+  event_displaying_day?: string | null;
+  event_type?: string | null;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+interface EventsResponse {
+  events?: ApiEvent[];
+}
+
+const normalizeEventType = (type?: string | null): EventType => {
+  if (type === '1' || type === 'tournament') {
+    return 'tournament';
+  }
+  if (type === '2' || type === 'announcement') {
+    return 'announcement';
+  }
+  return 'other';
+};
+
 /**
  * イベント登録API
  */
 export const registerEvent = async (formData: EventFormData) => {
-  try {
-    // イベントタイプの変換
-    let type = '2'; // デフォルト: その他
-    if (formData.type === 'tournament') {
-      type = '1';
-    } else if (formData.type === 'announcement' || formData.type === 'other') {
-      type = '2';
-    }
-
-    // 日付の変換 (YYYY-MM-DD -> ISO 8601)
-    // 締切と表示期限は、その日の終わり(23:59:59)とする
-    const deadline = new Date(`${formData.deadline}T23:59:59`).toISOString();
-    const endDisplayDate = new Date(`${formData.endDisplayDate}T23:59:59`).toISOString();
-
-    const response = await apiClient.post('/api/v2/events', {
-      name: formData.name,
-      details: formData.details,
-      url: formData.url,
-      type: type,
-      deadline: deadline,
-      endDisplayDate: endDisplayDate,
-    });
-    return { status: 'success', data: response };
-  } catch (error: any) {
-    console.error('Failed to register event:', error);
-    return {
-      status: 'error',
-      message: error.message || 'イベントの登録に失敗しました'
-    };
+  // イベントタイプの変換
+  let type = '2'; // デフォルト: その他
+  if (formData.type === 'tournament') {
+    type = '1';
+  } else if (formData.type === 'announcement' || formData.type === 'other') {
+    type = '2';
   }
+
+  // 日付の変換 (YYYY-MM-DD -> ISO 8601)
+  // 締切と表示期限は、その日の終わり(23:59:59)とする
+  const deadline = new Date(`${formData.deadline}T23:59:59`).toISOString();
+  const endDisplayDate = new Date(
+    `${formData.endDisplayDate}T23:59:59`
+  ).toISOString();
+
+  return apiClient.post('/api/v2/events', {
+    name: formData.name,
+    details: formData.details,
+    url: formData.url,
+    type: type,
+    deadline: deadline,
+    endDisplayDate: endDisplayDate,
+  });
 };
 
 /**
  * イベント一覧取得API
  */
 export const fetchEvents = async (): Promise<EventData[]> => {
-  const response = await apiClient.get<any>('/api/v2/events');
+  const response = await apiClient.get<EventsResponse>('/api/v2/events');
 
   // APIレスポンス: { data: { events: [...] } } 形式
   // Hono API v2 returns { data: { events: [...], pagination: {...} } }
   const rawEvents = response.data?.events ?? [];
 
   // スネークケース→キャメルケース変換
-  const events = rawEvents.map((event: any) => ({
+  const events = rawEvents.map(event => ({
     id: String(event.id),
     name: event.event_name ?? '',
     details: event.event_details ?? '',
     url: event.event_reference_url ?? '',
     deadline: event.event_closing_day ?? '',
     endDisplayDate: event.event_displaying_day ?? '',
-    type: event.event_type ?? '',
+    type: normalizeEventType(event.event_type),
     created_at: event.created_at,
-    updatedAt: event.updated_at,
+    updatedAt: event.updated_at ?? '',
     isActive: true, // v2 API doesn't have is_active yet, assuming true
   }));
 

--- a/hono-worker/src/index.ts
+++ b/hono-worker/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 import { setupCORS } from './middleware/cors';
-import { notFoundHandler } from './middleware/error';
+import { createHttpErrorResponse, notFoundHandler } from './middleware/error';
 import auth from './routes/auth';
 import discord from './routes/discord';
 import events from './routes/events';
@@ -19,13 +19,7 @@ app.use('*', setupCORS());
 // グローバルエラーハンドラー (onErrorを使用)
 app.onError((error, c) => {
     if (error instanceof HTTPException) {
-        const response: ErrorResponse = {
-            error: {
-                message: error.message,
-                code: `HTTP_${error.status}`,
-            },
-        };
-        return c.json(response, error.status);
+        return c.json(createHttpErrorResponse(error), error.status);
     }
 
     if (error instanceof Error) {

--- a/hono-worker/src/middleware/error.test.ts
+++ b/hono-worker/src/middleware/error.test.ts
@@ -1,0 +1,62 @@
+import { HTTPException } from 'hono/http-exception';
+import { describe, expect, it } from 'vitest';
+import { createHttpErrorResponse } from './error';
+
+describe('createHttpErrorResponse', () => {
+    it('バリデーションエラーのfield errorsだけをdetailsとして返す', async () => {
+        const response = createHttpErrorResponse(
+            new HTTPException(400, {
+                message: 'Validation failed',
+                cause: {
+                    name: ['Name is required'],
+                    deadline: ['Invalid datetime'],
+                },
+            })
+        );
+
+        expect(response).toEqual({
+            error: {
+                message: 'Validation failed',
+                code: 'HTTP_400',
+                details: {
+                    name: ['Name is required'],
+                    deadline: ['Invalid datetime'],
+                },
+            },
+        });
+    });
+
+    it('汎用causeは内部情報漏洩防止のためdetailsに返さない', async () => {
+        const response = createHttpErrorResponse(
+            new HTTPException(500, {
+                message: 'Database failed',
+                cause: new Error('select * from secret_table failed'),
+            })
+        );
+
+        expect(response).toEqual({
+            error: {
+                message: 'Database failed',
+                code: 'HTTP_500',
+            },
+        });
+        expect(response.error.details).toBeUndefined();
+    });
+
+    it('field errors以外のobject causeもdetailsに返さない', async () => {
+        const response = createHttpErrorResponse(
+            new HTTPException(400, {
+                message: 'Invalid token',
+                cause: { code: 'INVALID_TOKEN' },
+            })
+        );
+
+        expect(response).toEqual({
+            error: {
+                message: 'Invalid token',
+                code: 'HTTP_400',
+            },
+        });
+        expect(response.error.details).toBeUndefined();
+    });
+});

--- a/hono-worker/src/middleware/error.ts
+++ b/hono-worker/src/middleware/error.ts
@@ -2,6 +2,37 @@ import type { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { ErrorResponse } from '../types/api';
 
+type ValidationErrorDetails = Record<string, string[]>;
+
+function isValidationErrorDetails(value: unknown): value is ValidationErrorDetails {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+
+    const fieldErrors = Object.values(value);
+    if (fieldErrors.length === 0) {
+        return false;
+    }
+
+    return fieldErrors.every(
+        fieldError =>
+            Array.isArray(fieldError) && fieldError.every(message => typeof message === 'string')
+    );
+}
+
+export function createHttpErrorResponse(error: HTTPException): ErrorResponse {
+    const cause = (error as HTTPException & { cause?: unknown }).cause;
+    const details = isValidationErrorDetails(cause) ? cause : undefined;
+
+    return {
+        error: {
+            message: error.message,
+            code: `HTTP_${error.status}`,
+            ...(details ? { details } : {}),
+        },
+    };
+}
+
 /**
  * グローバルエラーハンドリングミドルウェア
  */
@@ -16,14 +47,7 @@ export async function errorHandler(c: Context, next: Next) {
             console.log('[Error Middleware] Status:', error.status);
             console.log('[Error Middleware] Message:', error.message);
 
-            const cause = (error as HTTPException & { cause?: unknown }).cause;
-            const response: ErrorResponse = {
-                error: {
-                    message: error.message,
-                    code: `HTTP_${error.status}`,
-                    ...(cause ? { details: cause } : {}),
-                },
-            };
+            const response = createHttpErrorResponse(error);
 
             console.log('[Error Middleware] Sending response:', JSON.stringify(response));
             return c.json(response, error.status);

--- a/hono-worker/src/middleware/error.ts
+++ b/hono-worker/src/middleware/error.ts
@@ -16,10 +16,12 @@ export async function errorHandler(c: Context, next: Next) {
             console.log('[Error Middleware] Status:', error.status);
             console.log('[Error Middleware] Message:', error.message);
 
+            const cause = (error as HTTPException & { cause?: unknown }).cause;
             const response: ErrorResponse = {
                 error: {
                     message: error.message,
                     code: `HTTP_${error.status}`,
+                    ...(cause ? { details: cause } : {}),
                 },
             };
 

--- a/hono-worker/src/routes/events.ts
+++ b/hono-worker/src/routes/events.ts
@@ -37,7 +37,7 @@ events.get('/', async c => {
       FROM events
       WHERE event_displaying_day >= NOW()
     `;
-    const total = parseInt(countResult[0].count as string);
+    const total = parseInt(countResult[0].count as string, 10);
 
     // イベント一覧を取得（表示期限内のもののみ）
     const eventsList = await sql`
@@ -93,7 +93,7 @@ events.get('/me', authMiddleware, async c => {
         SELECT COUNT(*) as count FROM events
         WHERE register_user_id = ${user.userId}
     `;
-    const total = parseInt(countResult[0].count as string);
+    const total = parseInt(countResult[0].count as string, 10);
 
     // イベント一覧を取得（認証ユーザーのみ）
     const eventsList = await sql`
@@ -131,9 +131,10 @@ events.get('/:id', async c => {
     const id = c.req.param('id');
 
     // IDのバリデーション
-    if (!/^\d+$/.test(id)) {
+    if (!id || !/^\d+$/.test(id)) {
         throw new HTTPException(400, { message: 'Invalid event ID' });
     }
+    const eventId = parseInt(id, 10);
 
     // データベース接続
     const sql = neon(c.env.DATABASE_URL);
@@ -144,7 +145,7 @@ events.get('/:id', async c => {
       id, register_user_id, event_name, event_details, event_reference_url,
       event_type, event_closing_day, event_displaying_day, created_at, updated_at
     FROM events
-    WHERE id = ${parseInt(id)}
+    WHERE id = ${eventId}
   `;
 
     if (eventsList.length === 0) {
@@ -171,7 +172,10 @@ events.post('/', authMiddleware, async c => {
     // バリデーション
     const result = eventRegistrationSchema.safeParse(body);
     if (!result.success) {
-        throw new HTTPException(400, { message: 'Validation failed', cause: result.error });
+        throw new HTTPException(400, {
+            message: 'Validation failed',
+            cause: result.error.flatten().fieldErrors,
+        });
     }
 
     const input = result.data;
@@ -222,16 +226,17 @@ events.delete('/:id', authMiddleware, async c => {
     const user = c.get('user');
 
     // IDのバリデーション
-    if (!/^\d+$/.test(id)) {
+    if (!id || !/^\d+$/.test(id)) {
         throw new HTTPException(400, { message: 'Invalid event ID' });
     }
+    const eventId = parseInt(id, 10);
 
     // データベース接続
     const sql = neon(c.env.DATABASE_URL);
 
     // イベントの存在確認と権限チェック
     const existingEvents = await sql`
-        SELECT register_user_id FROM events WHERE id = ${parseInt(id)}
+        SELECT register_user_id FROM events WHERE id = ${eventId}
     `;
 
     if (existingEvents.length === 0) {
@@ -247,7 +252,7 @@ events.delete('/:id', authMiddleware, async c => {
     }
 
     // イベントを削除
-    await sql`DELETE FROM events WHERE id = ${parseInt(id)}`;
+    await sql`DELETE FROM events WHERE id = ${eventId}`;
 
     return c.json({ message: 'Event deleted successfully' }, 200);
 });

--- a/hono-worker/src/routes/events.ts
+++ b/hono-worker/src/routes/events.ts
@@ -172,7 +172,7 @@ events.post('/', authMiddleware, async c => {
     // バリデーション
     const result = eventRegistrationSchema.safeParse(body);
     if (!result.success) {
-        throw new HTTPException(400, {
+        throw new HTTPException(422, {
             message: 'Validation failed',
             cause: result.error.flatten().fieldErrors,
         });


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event registration UI with form validation, confirmation dialog, and success/error flows

* **Improvements**
  * Clearer validation feedback on failed registrations and more consistent error responses (returns proper validation status)
  * More reliable date handling for deadline/end-of-day behavior

* **Tests**
  * Added end-to-end and unit tests to cover event registration and error responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Important Notes

This PR also fixes the event type code mapping used when registering events:

* `tournament` -> `1`
* `announcement` -> `2`
* `other` -> `3`

Previously, `other` was sent as `2`, which overlapped with `announcement`. The default value in `registerEvent` was also changed from `2` to `3` so unknown or fallback event types are stored as `other`.

`registerEvent` now preserves API failures by throwing instead of converting them into `{ status: 'error', message: ... }`. The only production caller is `useEventRegistration`, which passes the mutation error through React Query `onError`. `EventRegistrationForm` consumes that `onError` callback, so no production caller remains that branches on `result.status`.